### PR TITLE
Testbench support for Crossover

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -110,7 +110,7 @@ check_optimization(fma -mfma -DOPS_FMA)
 check_optimization(hifi2ep -mhifi2ep -DOPS_HIFI2EP)
 check_optimization(hifi3 -mhifi3 -DOPS_HIFI3)
 
-set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock)
+set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock crossover)
 
 # sources for each module
 set(volume_sources volume/volume.c volume/volume_generic.c)
@@ -119,6 +119,7 @@ set(asrc_sources asrc/asrc.c asrc/asrc_farrow.c asrc/asrc_farrow_generic.c)
 set(eq-fir_sources eq_fir/eq_fir.c eq_fir/fir.c)
 set(eq-iir_sources eq_iir/eq_iir.c eq_iir/iir.c eq_iir/iir_generic.c)
 set(dcblock_sources dcblock/dcblock.c dcblock/dcblock_generic.c)
+set(crossover_sources crossover/crossover.c crossover/crossover_generic.c)
 
 foreach(audio_module ${sof_audio_modules})
 	# first compile with no optimizations

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -760,14 +760,16 @@ static int crossover_prepare(struct comp_dev *dev)
 		  source->stream.channels);
 
 	/* Initialize Crossover */
-	/* To use this with testbench do not validate the config since the number
-	 * of assigned sinks will not match the number of actual sink buffers.
+	/* When running crossover on testbench, the config will always be
+	 * invalid since we can only have one sink buffer.
+	 * The number of assigned sinks will not match the number of actual sink buffers.
+	 * Therefore, do not take any action.
 	 */
-// 	if (cd->config && crossover_validate_config(dev, cd->config) < 0) {
-// 		/* If config is invalid then delete it.*/
-// 		comp_err(dev, "crossover_prepare(), invalid binary config format");
-// 		crossover_free_config(&cd->config);
-// 	}
+ 	if (cd->config && crossover_validate_config(dev, cd->config) < 0) {
+ 		/* If config is invalid then delete it.*/
+ 		comp_err(dev, "crossover_prepare(), invalid binary config format");
+ 		// crossover_free_config(&cd->config);
+ 	}
 
 	if (cd->config) {
 		ret = crossover_setup(cd, source->stream.channels);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -643,9 +643,12 @@ static int crossover_copy(struct comp_dev *dev)
 	 * to be assigned: sink[i] can be NULL, 0 <= i <= config->num_sinks
 	 */
 	num_assigned_sinks = crossover_assign_sinks(dev, cd->config, sinks);
-	if (cd->config && num_assigned_sinks != cd->config->num_sinks)
-		comp_dbg(dev, "crossover_copy(), number of assigned sinks (%i) does not match number of sinks in config (%i).",
-			 num_assigned_sinks, cd->config->num_sinks);
+	/* For testbench use, we do not expect the number of actual sink buffers to match
+	 * the config
+	 */
+// 	if (cd->config && num_assigned_sinks != cd->config->num_sinks)
+// 		comp_dbg(dev, "crossover_copy(), number of assigned sinks (%i) does not match number of sinks in config (%i).",
+// 			 num_assigned_sinks, cd->config->num_sinks);
 
 	/* If no config is set then assign the number of sinks to the number
 	 * of sinks that were assigned
@@ -757,11 +760,14 @@ static int crossover_prepare(struct comp_dev *dev)
 		  source->stream.channels);
 
 	/* Initialize Crossover */
-	if (cd->config && crossover_validate_config(dev, cd->config) < 0) {
-		/* If config is invalid then delete it.*/
-		comp_err(dev, "crossover_prepare(), invalid binary config format");
-		crossover_free_config(&cd->config);
-	}
+	/* To use this with testbench do not validate the config since the number
+	 * of assigned sinks will not match the number of actual sink buffers.
+	 */
+// 	if (cd->config && crossover_validate_config(dev, cd->config) < 0) {
+// 		/* If config is invalid then delete it.*/
+// 		comp_err(dev, "crossover_prepare(), invalid binary config format");
+// 		crossover_free_config(&cd->config);
+// 	}
 
 	if (cd->config) {
 		ret = crossover_setup(cd, source->stream.channels);

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -145,29 +145,26 @@ static void crossover_s16_default(const struct comp_dev *dev,
 	const struct audio_stream *source_stream = &source->stream;
 	struct audio_stream *sink_stream;
 	int16_t *x, *y;
-	int ch, i, j;
+	int i, j;
 	int idx = 0;
 	int nch = source_stream->channels;
 	int32_t out[num_sinks];
 
-	for (ch = 0; ch < nch; ch++) {
-		idx = ch;
-		state = &cd->state[ch];
-		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(source_stream, idx);
-			cd->crossover_split(*x << 16, out, state);
+	/* For testbench, reroute all the outputs to the channels of one buffer */
+	for (i = 0; i < frames; i++) {
+		x = audio_stream_read_frag_s16(source_stream, idx);
+		cd->crossover_split(*x << 16, out, state);
 
-			for (j = 0; j < num_sinks; j++) {
-				if (!sinks[j])
-					continue;
-				sink_stream = &sinks[j]->stream;
-				y = audio_stream_read_frag_s16(sink_stream,
-							       idx);
-				*y = sat_int16(Q_SHIFT_RND(out[j], 31, 15));
-			}
-
-			idx += nch;
+		for (j = 0; j < num_sinks; j++) {
+			if (!sinks[j])
+				continue;
+			sink_stream = &sinks[0]->stream;
+			y = audio_stream_read_frag_s16(sink_stream,
+						       idx + j);
+			*y = sat_int16(Q_SHIFT_RND(out[j], 31, 15));
 		}
+
+		idx += nch;
 	}
 }
 #endif // CONFIG_FORMAT_S16LE

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -151,6 +151,7 @@ static void crossover_s16_default(const struct comp_dev *dev,
 	int32_t out[num_sinks];
 
 	/* For testbench, reroute all the outputs to the channels of one buffer */
+	state = &cd->state[0];
 	for (i = 0; i < frames; i++) {
 		x = audio_stream_read_frag_s16(source_stream, idx);
 		cd->crossover_split(*x << 16, out, state);

--- a/tools/test/topology/tplg-build.sh
+++ b/tools/test/topology/tplg-build.sh
@@ -215,7 +215,7 @@ done
 
 # for processing algorithms
 # ALG_MODE_TESTS=(asrc eq-fir eq-iir src dcblock)
-ALG_MODE_TESTS=(crossover)
+ALG_MODE_TESTS=(crossover dcblock)
 # ALG_SIMPLE_TESTS=(test-capture test-playback)
 ALG_SIMPLE_TESTS=(test-playback)
 ALG_PROTOCOL_TESTS=(I2S)

--- a/tools/test/topology/tplg-build.sh
+++ b/tools/test/topology/tplg-build.sh
@@ -136,25 +136,25 @@ function simple_test {
 echo "Preparing topology build input..."
 
 # Pre-process the simple tests
-simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-
-simple_test codec passthrough "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec passthrough "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s24le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+# 
+# simple_test codec passthrough "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test codec passthrough "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test codec volume "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test codec volume "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test codec volume "SSP2-Codec" s24le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
+# simple_test codec volume "SSP2-Codec" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
 
 # for APL
-APL_PROTOCOL_TESTS=(I2S LEFT_J DSP_A DSP_B)
-APL_SSP_TESTS=(0 1 2 3 4 5)
-APL_MODE_TESTS=(volume)
-APL_FORMAT_TESTS=(s16le s24le s32le)
-MCLK_IDS=(0 1)
+# APL_PROTOCOL_TESTS=(I2S LEFT_J DSP_A DSP_B)
+# APL_SSP_TESTS=(0 1 2 3 4 5)
+# APL_MODE_TESTS=(volume)
+# APL_FORMAT_TESTS=(s16le s24le s32le)
+# MCLK_IDS=(0 1)
 
 for protocol in ${APL_PROTOCOL_TESTS[@]}
 do
@@ -214,8 +214,10 @@ done
 
 
 # for processing algorithms
-ALG_MODE_TESTS=(asrc eq-fir eq-iir src dcblock)
-ALG_SIMPLE_TESTS=(test-capture test-playback)
+# ALG_MODE_TESTS=(asrc eq-fir eq-iir src dcblock)
+ALG_MODE_TESTS=(crossover)
+# ALG_SIMPLE_TESTS=(test-capture test-playback)
+ALG_SIMPLE_TESTS=(test-playback)
 ALG_PROTOCOL_TESTS=(I2S)
 ALG_SSP_TESTS=(5)
 ALG_MCLK_IDS=(0)
@@ -237,20 +239,20 @@ do
 done
 
 # for CNL
-simple_test nocodec passthrough "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec passthrough "NoCodec-2" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s16le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s24le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-
-simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s24le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec src "NoCodec-4" s24le SSP 4 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec passthrough "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec passthrough "NoCodec-2" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-0" s16le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-0" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-0" s24le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# 
+# simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec volume "NoCodec-2" s24le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+# simple_test nocodec src "NoCodec-4" s24le SSP 4 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
 
 # algorithms tests
 

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -18,7 +18,7 @@
 #define MAX_LIB_NAME_LEN	256
 
 /* number of widgets types supported in testbench */
-#define NUM_WIDGETS_SUPPORTED	7
+#define NUM_WIDGETS_SUPPORTED	6
 
 struct testbench_prm {
 	char *tplg_file; /* topology file to use */

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -19,12 +19,11 @@
 /* shared library look up table */
 struct shared_lib_table lib_table[NUM_WIDGETS_SUPPORTED] = {
 	{"file", "", SOF_COMP_HOST, 0, NULL}, /* File must be first */
-	{"volume", "libsof_volume.so", SOF_COMP_VOLUME, 0, NULL},
-	{"src", "libsof_src.so", SOF_COMP_SRC, 0, NULL},
 	{"asrc", "libsof_asrc.so", SOF_COMP_ASRC, 0, NULL},
 	{"eq-fir", "libsof_eq-fir.so", SOF_COMP_EQ_FIR, 0, NULL},
 	{"eq-iir", "libsof_eq-iir.so", SOF_COMP_EQ_IIR, 0, NULL},
-	{"dcblock", "libsof_dcblock.so", SOF_COMP_DCBLOCK, 0, NULL}
+	{"dcblock", "libsof_dcblock.so", SOF_COMP_DCBLOCK, 0, NULL},
+	{"crossover", "libsof_crossover.so", SOF_COMP_CROSSOVER, 0, NULL}
 };
 
 /* main firmware context */
@@ -130,7 +129,7 @@ static void parse_input_args(int argc, char **argv, struct testbench_prm *tp)
 	int option = 0;
 	int ret = 0;
 
-	while ((option = getopt(argc, argv, "hdi:o:t:b:a:r:R:")) != -1) {
+	while ((option = getopt(argc, argv, "hdi:o:t:b:a:r:R:c:")) != -1) {
 		switch (option) {
 		/* input sample file */
 		case 'i':
@@ -166,6 +165,10 @@ static void parse_input_args(int argc, char **argv, struct testbench_prm *tp)
 		/* output sample rate */
 		case 'R':
 			tp->fs_out = atoi(optarg);
+			break;
+
+		case 'c':
+			tp->channels = atoi(optarg);
 			break;
 
 		/* enable debug prints */
@@ -275,7 +278,7 @@ int main(int argc, char **argv)
 	n_in = frcd->fs.n;
 	n_out = fwcd->fs.n;
 	t_exec = (double)(toc - tic) / CLOCKS_PER_SEC;
-	c_realtime = (double)n_out / TESTBENCH_NCH / tp.fs_out / t_exec;
+	c_realtime = (double)n_out / tp.channels / tp.fs_out / t_exec;
 
 	/* free all components/buffers in pipeline */
 	free_comps();

--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -23,12 +23,9 @@ include(`platform/intel/dmic.m4')
 # Define the pipelines
 #
 # PCM0  ----> volume (pipe 1)   -----> SSP1 (speaker - maxim98357a, BE link 0)
-# PCM1  <---> volume (pipe 2,3) <----> SSP2 (headset - da7219, BE link 1)
-`# PCM99 <---- 'DMICPROC` <---- DMIC0 (dmic capture, BE link 2)'
-# PCM5  ----> volume (pipe 5)   -----> iDisp1 (HDMI/DP playback, BE link 3)
-# PCM6  ----> Volume (pipe 6)   -----> iDisp2 (HDMI/DP playback, BE link 4)
-# PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
-#
+# PCM5  ----> Crossover
+# PCM6  ----> Crossover
+# PCM7  ----> Crossover
 
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
@@ -41,55 +38,6 @@ dnl     time_domain, sched_comp)
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# if DMICPROC is not defined, default pipepline is volume
-ifdef(`DMICPROC', , `define(DMICPROC, volume)')
-define(DEF_PIPE_DMIC_CAPTURE, sof/pipe-DMICPROC-capture.m4)
-
-# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(DEF_PIPE_DMIC_CAPTURE,
-	4, 99, 4, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-# PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        5, 5, 2, s32le,
-        1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-# PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        6, 6, 2, s32le,
-        1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-# PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        7, 7, 2, s32le,
-        1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -108,54 +56,75 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	2, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_2, 2, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+# currently this dai is here as "virtual" capture backend
+W_DAI_IN(SSP, 10, SSP1-Codec, s32le, 3, 0)
 
-# capture DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	3, SSP, 2, SSP2-Codec,
-	PIPELINE_SINK_3, 2, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+# Capture pipeline 10 on PCM 5 using max 2 channels of s32le.
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,
+	10, 5, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+# Capture pipeline 11 on PCM 6 using max 2 channels of s32le.
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,
+	11, 6, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        5, HDA, 3, iDisp1,
-        PIPELINE_SOURCE_5, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+# Capture pipeline 12 on PCM 7 using max 2 channels of s32le.
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,
+	12, 7, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        6, HDA, 4, iDisp2,
-        PIPELINE_SOURCE_6, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+# Connect demux to capture
+SectionGraph."PIPE_CAP" {
+	index "0"
 
-# playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        7, HDA, 5, iDisp3,
-        PIPELINE_SOURCE_7, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	lines [
+		# demux to capture
+		dapm(PIPELINE_SINK_10, PIPELINE_CROSSOVER_1)
+		# dapm(PIPELINE_SINK_11, PIPELINE_CROSSOVER_1)
+		# dapm(PIPELINE_SINK_12, PIPELINE_CROSSOVER_1)
+	]
+}
+
+# Connect virtual capture to dai
+SectionGraph."PIPE_CAP_VIRT" {
+	index "10"
+
+	lines [
+		dapm(ECHO REF 10, `SSP1.IN')
+	]
+}
+
+# Connect virtual capture to dai
+SectionGraph."PIPE_CAP_VIRT" {
+	index "11"
+
+	lines [
+		# mux to capture
+		dapm(ECHO REF 11, `SSP1.IN')
+	]
+}
+
+# Connect virtual capture to dai
+SectionGraph."PIPE_CAP_VIRT" {
+	index "12"
+
+	lines [
+		# mux to capture
+		dapm(ECHO REF 12, `SSP1.IN')
+	]
+}
 
 PCM_PLAYBACK_ADD(Speakers, 0, PIPELINE_PCM_1)
-PCM_DUPLEX_ADD(Headset, 1, PIPELINE_PCM_2, PIPELINE_PCM_3)
-PCM_CAPTURE_ADD(DMIC, 99, PIPELINE_PCM_4)
-PCM_PLAYBACK_ADD(HDMI1, 5, PIPELINE_PCM_5)
-PCM_PLAYBACK_ADD(HDMI2, 6, PIPELINE_PCM_6)
-PCM_PLAYBACK_ADD(HDMI3, 7, PIPELINE_PCM_7)
+PCM_CAPTURE_ADD(EchoRef, 10, PIPELINE_PCM_10)
+PCM_CAPTURE_ADD(EchoRef2, 11, PIPELINE_PCM_11)
+PCM_CAPTURE_ADD(EchoRef3, 12, PIPELINE_PCM_12)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -168,28 +137,6 @@ DAI_CONFIG(SSP, 1, 0, SSP1-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 16, 3, 3),
 		SSP_CONFIG_DATA(SSP, 1, 16, 1)))
-
-#SSP 2 (ID: 1) with 19.2 MHz mclk with MCLK_ID 1, 1.92 MHz bclk
-DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
-	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
-		SSP_CLOCK(bclk, 1920000, codec_slave),
-		SSP_CLOCK(fsync, 48000, codec_slave),
-		SSP_TDM(2, 20, 3, 3),
-		SSP_CONFIG_DATA(SSP, 2, 16, 1)))
-
-# dmic01 (id: 2)
-DAI_CONFIG(DMIC, 0, 2, dmic01,
-	DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
-		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
-		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
-
-# 3 HDMI/DP outputs (ID: 3,4,5)
-DAI_CONFIG(HDA, 3, 3, iDisp1,
-	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 3, 48000, 2)))
-DAI_CONFIG(HDA, 4, 4, iDisp2,
-	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 4, 48000, 2)))
-DAI_CONFIG(HDA, 5, 5, iDisp3,
-	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 5, 48000, 2)))
 
 ## remove warnings with SST hard-coded routes
 

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -53,6 +53,7 @@ enum sof_ipc_process_type {
 	SOF_PROCESS_MUX,
 	SOF_PROCESS_DEMUX,
 	SOF_PROCESS_DCBLOCK,
+	SOF_PROCESS_CROSSOVER,
 };
 
 struct sof_topology_token {

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -33,7 +33,8 @@ static const struct sof_process_types sof_process[] = {
 	{"CHAN_SELECTOR", SOF_PROCESS_CHAN_SELECTOR, SOF_COMP_SELECTOR},
 	{"MUX", SOF_PROCESS_MUX, SOF_COMP_MUX},
 	{"DEMUX", SOF_PROCESS_DEMUX, SOF_COMP_DEMUX},
-	{"DCBLOCK", SOF_PROCESS_DCBLOCK, SOF_COMP_DCBLOCK}
+	{"DCBLOCK", SOF_PROCESS_DCBLOCK, SOF_COMP_DCBLOCK},
+	{"CROSSOVER", SOF_PROCESS_CROSSOVER, SOF_COMP_CROSSOVER}
 };
 
 static enum sof_ipc_process_type find_process(const char *name)


### PR DESCRIPTION
This PR adds testbench support for crossover.

It modifies the crossover code so that all the outputs are routed to the channels on one sink.

This is one way I found to go around the 1 source, 1 sink restrictions on the sof testbench.

To run testbench:

````bash
cd sof/
# build the test topologies
./scripts/docker-run.sh ./scripts/build-tools.sh -t
# compile sof for host and tesbench
./scripts/docker-run.sh ./scripts/host-build-all.sh

# the test topologies should be under tools/build_tools/test/toplogy/
# and the testbench binary should be under tools/testbench/build_testbench
# run the testbench binary. you may need to run it within the docker container since it requires libsof.so
# Example Usage:
./tools/testbench/build_testbench/testbench -i in.txt -o out.txt -t test.tplg -r 48000 -R 96000 -c <num_channels> -b S16_LE -a vol=libsof_volume.so
````