### PR TITLE
tools: Support multi-output component playback testing on testbench

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -110,7 +110,7 @@ check_optimization(fma -mfma -DOPS_FMA)
 check_optimization(hifi2ep -mhifi2ep -DOPS_HIFI2EP)
 check_optimization(hifi3 -mhifi3 -DOPS_HIFI3)
 
-set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock)
+set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock crossover)
 
 # sources for each module
 set(volume_sources volume/volume.c volume/volume_generic.c)
@@ -119,6 +119,7 @@ set(asrc_sources asrc/asrc.c asrc/asrc_farrow.c asrc/asrc_farrow_generic.c)
 set(eq-fir_sources eq_fir/eq_fir.c eq_fir/fir.c)
 set(eq-iir_sources eq_iir/eq_iir.c eq_iir/iir.c eq_iir/iir_generic.c)
 set(dcblock_sources dcblock/dcblock.c dcblock/dcblock_generic.c)
+set(crossover_sources crossover/crossover.c crossover/crossover_generic.c)
 
 foreach(audio_module ${sof_audio_modules})
 	# first compile with no optimizations

--- a/src/include/kernel/header.h
+++ b/src/include/kernel/header.h
@@ -34,6 +34,6 @@ struct sof_abi_hdr {
 	uint32_t abi;		/**< SOF ABI version */
 	uint32_t reserved[4];	/**< reserved for future use */
 	uint32_t data[0];	/**< Component data - opaque to core */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __KERNEL_HEADER_H__ */

--- a/src/include/user/eq.h
+++ b/src/include/user/eq.h
@@ -151,7 +151,7 @@ struct sof_eq_iir_biquad_df2t {
 	int32_t b0; /* Q2.30 */
 	int32_t output_shift; /* Number of right shifts */
 	int32_t output_gain;  /* Q2.14 */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* A full 22th order equalizer with 11 biquads cover octave bands 1-11 in
  * in the 0 - 20 kHz bandwidth.

--- a/tools/test/topology/test-playback.m4
+++ b/tools/test/topology/test-playback.m4
@@ -19,6 +19,9 @@ include(`platform/intel/bxt.m4')
 
 DEBUG_START
 
+dnl Produce uppercase for input string
+define(`upcase', `translit(`$*', `a-z', `A-Z')')
+
 #
 # Machine Specific Config - !! MUST BE SET TO MATCH TEST MACHINE DRIVER !!
 #
@@ -32,6 +35,7 @@ DEBUG_START
 # TEST_SSP_PHY_BITS - SSP physical slot size
 # TEST_SSP_DATA_BITS - SSP data slot size
 # TEST_SSP_MODE - SSP mode e.g. I2S, LEFT_J, DSP_A and DSP_B
+# TEST_PIPE_AMOUNT - Total amount of pipelines e.g. 1, 2, 3, 4
 #
 
 # Apply a non-trivial filter blob IIR and FIR tests. TODO: Note that the
@@ -39,10 +43,42 @@ DEBUG_START
 define(PIPELINE_FILTER1, ifelse(TEST_PIPE_NAME, `eq-iir', `eq_iir_coef_loudness.m4'))
 define(PIPELINE_FILTER2, ifelse(TEST_PIPE_NAME, `eq-fir', `eq_fir_coef_loudness.m4'))
 
+# Define HAS_PIPEn flags according to TEST_PIPE_AMOUNT. Those flags will be used to
+# determine whether PIPELINE_n should be added.
+ifelse(TEST_PIPE_AMOUNT, `2',
+`
+define(HAS_PIPE2)
+')
+
+ifelse(TEST_PIPE_AMOUNT, `3',
+`
+define(HAS_PIPE2)
+define(HAS_PIPE3)
+')
+
+ifelse(TEST_PIPE_AMOUNT, `4',
+`
+define(HAS_PIPE2)
+define(HAS_PIPE3)
+define(HAS_PIPE4)
+')
+
 #
-# Define the pipeline
+# Define the pipeline(s)
 #
-# PCM0P  -->  TEST_PIPE_NAME  -->  SSP(TEST_DAI_PORT)
+# PCM0P --> BUF1.0 --> TEST_PIPE_NAME --> BUF1.1 --> SSP(TEST_DAI_PORT)
+ifdef(`HAS_PIPE2',
+`
+#                                   +---> BUF2.0 --> SSP(0 or 1)
+')
+ifdef(`HAS_PIPE3',
+`
+#                                   +---> BUF3.0 --> SSP(2 or 3)
+')
+ifdef(`HAS_PIPE4',
+`
+#                                   +---> BUF4.0 --> SSP(4 or 5)
+')
 #
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s32le.
@@ -52,10 +88,71 @@ PIPELINE_PCM_ADD(sof/pipe-TEST_PIPE_NAME-playback.m4,
 	1000, 0, 0,
 	8000, 192000, 48000)
 
+# Generalize the pipeline junction name as PIPELINE_JUNCTION.
+# e.g. TEST_PIPE_NAME=`crossover' --> PIPELINE_JUNCTION=`PIPELINE_CROSSOVER_1'
+define(PIPELINE_JUNCTION, concat(concat(`PIPELINE_', upcase(TEST_PIPE_NAME)), `_1'))
+
+ifdef(`HAS_PIPE2',
+`
+# Playback pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-dai-endpoint.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	8000, 192000, 48000)
+
+# connect pipelines together
+SectionGraph."pipe-sof-second-pipe" {
+        index "2"
+
+        lines [
+		# connect the second sink buffer
+                dapm(PIPELINE_SOURCE_2, PIPELINE_JUNCTION)
+        ]
+}
+')
+
+ifdef(`HAS_PIPE3',
+`
+# Playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-dai-endpoint.m4,
+	3, 2, 2, s32le,
+	1000, 0, 0,
+	8000, 192000, 48000)
+
+# connect pipelines together
+SectionGraph."pipe-sof-third-pipe" {
+        index "3"
+
+        lines [
+		# connect the third sink buffer
+                dapm(PIPELINE_SOURCE_3, PIPELINE_JUNCTION)
+        ]
+}
+')
+
+ifdef(`HAS_PIPE4',
+`
+# Playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-dai-endpoint.m4,
+	4, 3, 2, s32le,
+	1000, 0, 0,
+	8000, 192000, 48000)
+
+# connect pipelines together
+SectionGraph."pipe-sof-fourth-pipe" {
+        index "4"
+
+        lines [
+		# connect the fourth sink buffer
+                dapm(PIPELINE_SOURCE_4, PIPELINE_JUNCTION)
+        ]
+}
+')
+
 # DAI configuration
-#
-# SSP port TEST_DAI_PORT is our only pipeline DAI
-#
 
 # playback DAI is SSP TEST_DAI_PORT using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
@@ -63,6 +160,48 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	1, TEST_DAI_TYPE, TEST_DAI_PORT, TEST_DAI_LINK_NAME,
 	PIPELINE_SOURCE_1, 2, TEST_DAI_FORMAT,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+ifdef(`HAS_PIPE2',
+`
+define(TEST_DAI2_PORT, ifelse(TEST_DAI_PORT, `0', `1', `0'))
+define(TEST_DAI2_LINK_NAME, ifelse(TEST_DAI_PORT, `0', `SSP1-Codec', `SSP0-Codec'))
+
+# playback DAI is SSP TEST_DAI2_PORT using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD_SCHED(sof/pipe-dai-sched-playback.m4,
+	2, TEST_DAI_TYPE, TEST_DAI2_PORT, TEST_DAI2_LINK_NAME,
+	PIPELINE_SOURCE_2, 2, TEST_DAI_FORMAT,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+')
+
+ifdef(`HAS_PIPE3',
+`
+define(TEST_DAI3_PORT, ifelse(TEST_DAI_PORT, `2', `3', `2'))
+define(TEST_DAI3_LINK_NAME, ifelse(TEST_DAI_PORT, `2', `SSP3-Codec', `SSP2-Codec'))
+
+# playback DAI is SSP TEST_DAI3_PORT using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD_SCHED(sof/pipe-dai-sched-playback.m4,
+	3, TEST_DAI_TYPE, TEST_DAI3_PORT, TEST_DAI3_LINK_NAME,
+	PIPELINE_SOURCE_3, 2, TEST_DAI_FORMAT,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+')
+
+ifdef(`HAS_PIPE4',
+`
+define(TEST_DAI4_PORT, ifelse(TEST_DAI_PORT, `4', `5', `4'))
+define(TEST_DAI4_LINK_NAME, ifelse(TEST_DAI_PORT, `4', `SSP5-Codec', `SSP4-Codec'))
+
+# playback DAI is SSP TEST_DAI4_PORT using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD_SCHED(sof/pipe-dai-sched-playback.m4,
+	4, TEST_DAI_TYPE, TEST_DAI4_PORT, TEST_DAI4_LINK_NAME,
+	PIPELINE_SOURCE_4, 2, TEST_DAI_FORMAT,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+')
 
 # PCM Passthrough
 PCM_PLAYBACK_ADD(Passthrough, 0, PIPELINE_PCM_1)
@@ -73,7 +212,7 @@ PCM_PLAYBACK_ADD(Passthrough, 0, PIPELINE_PCM_1)
 # Clocks masters wrt codec
 #
 # TEST_SSP_DATA_BITS bit I2S
-# using TEST_SSP_PHY_BITS bit sample container on SSP TEST_DAI_PORT
+# using TEST_SSP_PHY_BITS bit sample container on SSP port(s)
 #
 DAI_CONFIG(TEST_DAI_TYPE, TEST_DAI_PORT, 0, TEST_DAI_LINK_NAME,
 	   SSP_CONFIG(TEST_SSP_MODE,
@@ -84,5 +223,40 @@ DAI_CONFIG(TEST_DAI_TYPE, TEST_DAI_PORT, 0, TEST_DAI_LINK_NAME,
 		      SSP_CONFIG_DATA(TEST_DAI_TYPE, TEST_DAI_PORT,
 				      TEST_SSP_DATA_BITS, TEST_SSP_MCLK_ID)))
 
+ifdef(`HAS_PIPE2',
+`
+DAI_CONFIG(TEST_DAI_TYPE, TEST_DAI2_PORT, 1, TEST_DAI2_LINK_NAME,
+	   SSP_CONFIG(TEST_SSP_MODE,
+		      SSP_CLOCK(mclk, TEST_SSP_MCLK, codec_mclk_in),
+		      SSP_CLOCK(bclk, TEST_SSP_BCLK, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, TEST_SSP_PHY_BITS, 3, 3),
+		      SSP_CONFIG_DATA(TEST_DAI_TYPE, TEST_DAI2_PORT,
+				      TEST_SSP_DATA_BITS, TEST_SSP_MCLK_ID)))
+')
+
+ifdef(`HAS_PIPE3',
+`
+DAI_CONFIG(TEST_DAI_TYPE, TEST_DAI3_PORT, 2, TEST_DAI3_LINK_NAME,
+	   SSP_CONFIG(TEST_SSP_MODE,
+		      SSP_CLOCK(mclk, TEST_SSP_MCLK, codec_mclk_in),
+		      SSP_CLOCK(bclk, TEST_SSP_BCLK, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, TEST_SSP_PHY_BITS, 3, 3),
+		      SSP_CONFIG_DATA(TEST_DAI_TYPE, TEST_DAI3_PORT,
+				      TEST_SSP_DATA_BITS, TEST_SSP_MCLK_ID)))
+')
+
+ifdef(`HAS_PIPE4',
+`
+DAI_CONFIG(TEST_DAI_TYPE, TEST_DAI4_PORT, 3, TEST_DAI4_LINK_NAME,
+	   SSP_CONFIG(TEST_SSP_MODE,
+		      SSP_CLOCK(mclk, TEST_SSP_MCLK, codec_mclk_in),
+		      SSP_CLOCK(bclk, TEST_SSP_BCLK, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, TEST_SSP_PHY_BITS, 3, 3),
+		      SSP_CONFIG_DATA(TEST_DAI_TYPE, TEST_DAI4_PORT,
+				      TEST_SSP_DATA_BITS, TEST_SSP_MCLK_ID)))
+')
 
 DEBUG_END

--- a/tools/test/topology/tplg-build.sh
+++ b/tools/test/topology/tplg-build.sh
@@ -34,21 +34,22 @@ M4_STRINGS=""
 # 3) be_name - BE DAI link name in machine driver, used for matching
 # 4) format - PCM sample format
 # 5) dai_type - dai type e.g. SSP/DMIC
-# 5) dai_id - SSP port number
-# 6) dai_format - SSP sample format
-# 7) dai_phy_bits - SSP physical number of BLKCs per slot/channel
-# 8) dai_data_bits - SSP number of valid data bits per slot/channel
-# 9) dai_bclk - SSP BCLK in HZ
-# 10) dai_mclk - SSP MCLK in HZ
-# 11) SSP mode - SSP mode e.g. I2S, LEFT_J, DSP_A and DSP_B
-# 12) SSP mclk_id
-# 13) Test pipelines
+# 6) dai_id - SSP port number
+# 7) dai_format - SSP sample format
+# 8) dai_phy_bits - SSP physical number of BLKCs per slot/channel
+# 9) dai_data_bits - SSP number of valid data bits per slot/channel
+# 10) dai_bclk - SSP BCLK in HZ
+# 11) dai_mclk - SSP MCLK in HZ
+# 12) SSP mode - SSP mode e.g. I2S, LEFT_J, DSP_A and DSP_B
+# 13) SSP mclk_id
+# 14) total amount of pipeline - range from 1 to 4
+# 15) Test pipelines
 #
 
 function simple_test {
 	if [ $5 == "SSP" ]
 	then
-		TESTS=("${!14}")
+		TESTS=("${!15}")
 	elif [ $5 == "DMIC" ]
 	then
 		TESTS=("${!15}")
@@ -87,7 +88,12 @@ function simple_test {
 					then
 						TFILE="test-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
 					else
-						TFILE="$i-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+						if [ ${14} == "1" ]
+						then
+							TFILE="$i-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+						else
+							TFILE="$i-ssp$6-mclk-${13}-${12}-${14}way-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+						fi
 					fi
 					#create input string for batch m4 processing
 					M4_STRINGS+="-DTEST_PIPE_NAME=$2,-DTEST_DAI_LINK_NAME=$3\
@@ -95,7 +101,8 @@ function simple_test {
 						-DTEST_PIPE_FORMAT=$4,-DTEST_SSP_BCLK=${10}\
 						-DTEST_SSP_MCLK=${11},-DTEST_SSP_PHY_BITS=$8\
 						-DTEST_SSP_DATA_BITS=$9,-DTEST_SSP_MODE=${12}\
-						-DTEST_SSP_MCLK_ID=${13},-DTEST_DAI_TYPE=$5\
+						-DTEST_SSP_MCLK_ID=${13},-DTEST_PIPE_AMOUNT=${14}\
+						-DTEST_DAI_TYPE=$5\
 						$i.m4,$BUILD_OUTPUT/${TFILE},"
 					#create input string for batch processing of conf files
 					TEST_STRINGS+="$BUILD_OUTPUT/${TFILE},"
@@ -108,7 +115,12 @@ function simple_test {
 					then
 						TFILE="test-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
 					else
-						TFILE="$i-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+						if [ ${14} == "1" ]
+						then
+							TFILE="$i-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+						else
+							TFILE="$i-ssp$6-mclk-${13}-${12}-${14}way-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+						fi
 					fi
 					echo "M4 pre-processing test $i -> ${TFILE}"
 					m4 ${M4_FLAGS} \
@@ -123,6 +135,7 @@ function simple_test {
 						-DTEST_SSP_DATA_BITS=$9 \
 						-DTEST_SSP_MODE=${12} \
 						-DTEST_SSP_MCLK_ID=${13} \
+						-DTEST_PIPE_AMOUNT=${14} \
 						-DTEST_DAI_TYPE=$5 \
 						$i.m4 > "$BUILD_OUTPUT/${TFILE}.conf"
 					echo "Compiling test $i -> $BUILD_OUTPUT/${TFILE}.tplg"
@@ -136,18 +149,18 @@ function simple_test {
 echo "Preparing topology build input..."
 
 # Pre-process the simple tests
-simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 1 SIMPLE_TESTS[@]
 
-simple_test codec passthrough "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec passthrough "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s24le SSP 2 s16le 20 16 1920000 19200000 I2S 0 SIMPLE_TESTS[@]
-simple_test codec volume "SSP2-Codec" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 SIMPLE_TESTS[@]
+simple_test codec passthrough "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test codec passthrough "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test codec volume "SSP2-Codec" s16le SSP 2 s16le 20 16 1920000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test codec volume "SSP2-Codec" s24le SSP 2 s24le 25 24 2400000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test codec volume "SSP2-Codec" s24le SSP 2 s16le 20 16 1920000 19200000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test codec volume "SSP2-Codec" s16le SSP 2 s24le 25 24 2400000 19200000 I2S 0 1 SIMPLE_TESTS[@]
 
 # for APL
 APL_PROTOCOL_TESTS=(I2S LEFT_J DSP_A DSP_B)
@@ -166,25 +179,25 @@ do
 			do
 				for mclk_id in ${MCLK_IDS[@]}
 				do
-					simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-					simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-					simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
+					simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+					simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+					simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
 
-					simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-					simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-					simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
+					simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+					simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+					simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
 				done
 			done
 		done
 		for mclk_id in ${MCLK_IDS[@]}
 		do
-			simple_test nocodec passthrough "NoCodec-${ssp}" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-			simple_test nocodec passthrough "NoCodec-${ssp}" s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-			simple_test nocodec passthrough "NoCodec-${ssp}" s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
+			simple_test nocodec passthrough "NoCodec-${ssp}" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+			simple_test nocodec passthrough "NoCodec-${ssp}" s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+			simple_test nocodec passthrough "NoCodec-${ssp}" s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
 
-			simple_test codec passthrough "SSP${ssp}-Codec" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-			simple_test codec passthrough "SSP${ssp}-Codec"	s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
-			simple_test codec passthrough "SSP${ssp}-Codec"	s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id SIMPLE_TESTS[@]
+			simple_test codec passthrough "SSP${ssp}-Codec" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+			simple_test codec passthrough "SSP${ssp}-Codec"	s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
+			simple_test codec passthrough "SSP${ssp}-Codec"	s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id 1 SIMPLE_TESTS[@]
 		done
 	done
 done
@@ -197,25 +210,28 @@ do
 		do
 			for format in ${APL_FORMAT_TESTS[@]}
 			do
-				simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 SIMPLE_TESTS[@]
-				simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 SIMPLE_TESTS[@]
+				simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
+				simple_test nocodec $mode "NoCodec-${ssp}" $format SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
 
-				simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 SIMPLE_TESTS[@]
-				simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 SIMPLE_TESTS[@]
+				simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
+				simple_test codec $mode "SSP${ssp}-Codec" $format SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
 			done
 		done
-		simple_test nocodec passthrough "NoCodec-${ssp}" s16le SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 SIMPLE_TESTS[@]
-		simple_test nocodec passthrough "NoCodec-${ssp}" s24le SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 SIMPLE_TESTS[@]
+		simple_test nocodec passthrough "NoCodec-${ssp}" s16le SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
+		simple_test nocodec passthrough "NoCodec-${ssp}" s24le SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
 
-		simple_test codec passthrough "SSP${ssp}-Codec" s16le SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 SIMPLE_TESTS[@]
-		simple_test codec passthrough "SSP${ssp}-Codec" s24le SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 SIMPLE_TESTS[@]
+		simple_test codec passthrough "SSP${ssp}-Codec" s16le SSP $ssp s16le 20 16 1920000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
+		simple_test codec passthrough "SSP${ssp}-Codec" s24le SSP $ssp s24le 25 24 2400000 19200000 $protocol 0 1 SIMPLE_TESTS[@]
 	done
 done
 
 
 # for processing algorithms
-ALG_MODE_TESTS=(asrc eq-fir eq-iir src dcblock)
-ALG_SIMPLE_TESTS=(test-capture test-playback)
+ALG_SINGLE_MODE_TESTS=(asrc eq-fir eq-iir src dcblock)
+ALG_SINGLE_SIMPLE_TESTS=(test-capture test-playback)
+ALG_MULTI_MODE_TESTS=(crossover)
+ALG_MULTI_SIMPLE_TESTS=(test-playback)
+ALG_MULTI_PIPE_AMOUNT=(2 3 4)
 ALG_PROTOCOL_TESTS=(I2S)
 ALG_SSP_TESTS=(5)
 ALG_MCLK_IDS=(0)
@@ -224,33 +240,43 @@ for protocol in ${ALG_PROTOCOL_TESTS[@]}
 do
 	for ssp in ${ALG_SSP_TESTS[@]}
 	do
-		for mode in ${ALG_MODE_TESTS[@]}
+		for mclk_id in ${ALG_MCLK_IDS[@]}
 		do
-			for mclk_id in ${ALG_MCLK_IDS[@]}
+			for mode in ${ALG_SINGLE_MODE_TESTS[@]}
 			do
-				simple_test codec $mode "SSP${ssp}-Codec" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id ALG_SIMPLE_TESTS[@]
-				simple_test codec $mode "SSP${ssp}-Codec" s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id ALG_SIMPLE_TESTS[@]
-				simple_test codec $mode "SSP${ssp}-Codec" s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id ALG_SIMPLE_TESTS[@]
+				simple_test codec $mode "SSP${ssp}-Codec" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id 1 ALG_SINGLE_SIMPLE_TESTS[@]
+				simple_test codec $mode "SSP${ssp}-Codec" s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id 1 ALG_SINGLE_SIMPLE_TESTS[@]
+				simple_test codec $mode "SSP${ssp}-Codec" s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id 1 ALG_SINGLE_SIMPLE_TESTS[@]
+			done
+
+			for mode in ${ALG_MULTI_MODE_TESTS[@]}
+			do
+				for pipe_num in ${ALG_MULTI_PIPE_AMOUNT[@]}
+				do
+					simple_test codec $mode "SSP${ssp}-Codec" s16le SSP $ssp s16le 16 16 1536000 24576000 $protocol $mclk_id $pipe_num ALG_MULTI_SIMPLE_TESTS[@]
+					simple_test codec $mode "SSP${ssp}-Codec" s24le SSP $ssp s24le 32 24 3072000 24576000 $protocol $mclk_id $pipe_num ALG_MULTI_SIMPLE_TESTS[@]
+					simple_test codec $mode "SSP${ssp}-Codec" s32le SSP $ssp s32le 32 32 3072000 24576000 $protocol $mclk_id $pipe_num ALG_MULTI_SIMPLE_TESTS[@]
+				done
 			done
 		done
 	done
 done
 
 # for CNL
-simple_test nocodec passthrough "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec passthrough "NoCodec-2" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s16le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-0" s24le SSP 0 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+simple_test nocodec passthrough "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec passthrough "NoCodec-2" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-0" s16le SSP 0 s16le 25 16 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-0" s16le SSP 0 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-0" s24le SSP 0 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-0" s24le SSP 0 s16le 25 16 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
 
-simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec volume "NoCodec-2" s24le SSP 2 s16le 25 16 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
-simple_test nocodec src "NoCodec-4" s24le SSP 4 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
+simple_test nocodec passthrough "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec passthrough "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s16le SSP 2 s16le 25 16 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s16le SSP 2 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s24le SSP 2 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec volume "NoCodec-2" s24le SSP 2 s16le 25 16 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
+simple_test nocodec src "NoCodec-4" s24le SSP 4 s24le 25 24 2400000 24000000 I2S 0 1 SIMPLE_TESTS[@]
 
 # algorithms tests
 
@@ -259,7 +285,7 @@ then
 	echo "Batch processing m4 files..."
 	M4_STRINGS=${M4_STRINGS%?}
 	#m4 processing
-	echo $M4_STRINGS | tr " " "," | tr '\n' '\0' | xargs -P0 -d ',' -n14 bash -c 'm4 "${@:1:${#}-1}" > ${14}.conf' m4
+	echo $M4_STRINGS | tr " " "," | tr '\n' '\0' | xargs -P0 -d ',' -n15 bash -c 'm4 "${@:1:${#}-1}" > ${15}.conf' m4
 
 	#execute alsatplg to create topology binary
 	TEST_STRINGS=${TEST_STRINGS%?}

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -17,13 +17,16 @@
 #define DEBUG_MSG_LEN		256
 #define MAX_LIB_NAME_LEN	256
 
+#define MAX_OUTPUT_FILE_NUM	4
+
 /* number of widgets types supported in testbench */
-#define NUM_WIDGETS_SUPPORTED	7
+#define NUM_WIDGETS_SUPPORTED	8
 
 struct testbench_prm {
 	char *tplg_file; /* topology file to use */
 	char *input_file; /* input file name */
-	char *output_file; /* output file name */
+	char *output_file[MAX_OUTPUT_FILE_NUM]; /* output file names */
+	int output_file_num; /* number of output files */
 	char *bits_in; /* input bit format */
 	/*
 	 * input and output sample rate parameters
@@ -37,6 +40,7 @@ struct testbench_prm {
 	int fr_id;
 	int fw_id;
 	int sched_id;
+	int max_pipeline_id;
 	enum sof_ipc_frame frame_fmt;
 };
 

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -22,6 +22,7 @@
 FILE *file;
 char pipeline_string[DEBUG_MSG_LEN];
 struct shared_lib_table *lib_table;
+int output_file_index;
 
 const struct sof_dai_types sof_dais[] = {
 	{"SSP", SOF_DAI_INTEL_SSP},
@@ -332,9 +333,16 @@ static int load_filewrite(struct sof *sof, int comp_id, int pipeline_id,
 		return -EINVAL;
 	}
 
-	/* configure filewrite */
-	filewrite.fn = strdup(tp->output_file);
-	tp->fw_id = comp_id;
+	/* configure filewrite (multiple output files are supported.) */
+	if (!tp->output_file[output_file_index]) {
+		fprintf(stderr, "error: output[%d] file name is null\n",
+			output_file_index);
+		return -EINVAL;
+	}
+	filewrite.fn = strdup(tp->output_file[output_file_index]);
+	if (output_file_index == 0)
+		tp->fw_id = comp_id;
+	output_file_index++;
 
 	/* Set format from testbench command line*/
 	filewrite.rate = tp->fs_out;
@@ -671,6 +679,9 @@ int parse_topology(struct sof *sof, struct shared_lib_table *library_table,
 {
 	struct snd_soc_tplg_hdr *hdr;
 
+	/* initialize output file index */
+	output_file_index = 0;
+
 	struct comp_info *temp_comp_list = NULL;
 	char message[DEBUG_MSG_LEN];
 	int next_comp_id = 0;
@@ -728,6 +739,10 @@ int parse_topology(struct sof *sof, struct shared_lib_table *library_table,
 				hdr->count);
 
 			debug_print(message);
+
+			/* update max pipeline_id */
+			if (hdr->index > tp->max_pipeline_id)
+				tp->max_pipeline_id = hdr->index;
 
 			num_comps += hdr->count;
 			size = sizeof(struct comp_info) * num_comps;

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -53,6 +53,7 @@ enum sof_ipc_process_type {
 	SOF_PROCESS_MUX,
 	SOF_PROCESS_DEMUX,
 	SOF_PROCESS_DCBLOCK,
+	SOF_PROCESS_CROSSOVER,
 };
 
 struct sof_topology_token {

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -33,7 +33,8 @@ static const struct sof_process_types sof_process[] = {
 	{"CHAN_SELECTOR", SOF_PROCESS_CHAN_SELECTOR, SOF_COMP_SELECTOR},
 	{"MUX", SOF_PROCESS_MUX, SOF_COMP_MUX},
 	{"DEMUX", SOF_PROCESS_DEMUX, SOF_COMP_DEMUX},
-	{"DCBLOCK", SOF_PROCESS_DCBLOCK, SOF_COMP_DCBLOCK}
+	{"DCBLOCK", SOF_PROCESS_DCBLOCK, SOF_COMP_DCBLOCK},
+	{"CROSSOVER", SOF_PROCESS_CROSSOVER, SOF_COMP_CROSSOVER}
 };
 
 static enum sof_ipc_process_type find_process(const char *name)
@@ -1097,8 +1098,10 @@ int tplg_load_graph(int num_comps, int pipeline_id,
 	strcat(pipeline_string, graph_elem->source);
 	strcat(pipeline_string, "->");
 
-	if (route_num == (count - 1))
+	if (route_num == (count - 1)) {
 		strcat(pipeline_string, graph_elem->sink);
+		strcat(pipeline_string, "\n");
+	}
 
 	free(graph_elem);
 	return 0;
@@ -1138,7 +1141,8 @@ int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 	temp_comp_list[comp_index].type = widget->id;
 	temp_comp_list[comp_index].pipeline_id = pipeline_id;
 
-	printf("debug: loading widget %s id %d\n", widget->name, widget->id);
+	printf("debug: loading comp_id %d: widget %s id %d\n",
+	       comp_id, widget->name, widget->id);
 
 	/* load widget based on type */
 	switch (widget->id) {


### PR DESCRIPTION
This patch supports testbench playback testing for single-input-multi-output component, e.g. crossover. Test playback m4 file (tools/test/topology/test-playback.m4) is extended to generate up to 4 output pipelines test topologies, where argument "TEST_PIPE_AMOUNT" is provided for identifying the number of pipelines.

While building test topologies, 2way, 3way, and 4way crossover playback topology files will be generated under build_tools/test/topology/ with names as follows:
`test-playback-ssp5-mclk-0-I2S-2way-crossover-s16le-s16le-48k-24576k-codec.*`
`test-playback-ssp5-mclk-0-I2S-3way-crossover-s16le-s16le-48k-24576k-codec.*`
`test-playback-ssp5-mclk-0-I2S-4way-crossover-s16le-s16le-48k-24576k-codec.*`
and so on.

**Testbench Run**
For example of running 4way-crossover playback, the coefficient file with 4-sink crossover should be generated under tools/tune/crossover/ by

`octave example_crossover.m`

Then after building, run testbench by the following command:

`testbench -i input -o output_1,output_2,output_3,output_4 -t test-playback-ssp5-mclk-0-I2S-4way-crossover-s16le-s16le-48k-24576k-codec.tplg -r 48000 -R 48000 -c 1 -b S16_LE -a crossover=libsof_crossover.so`

where argument "-o" now accepts specifying up to 4 output file names delimited by comma (in 4way case 4 files should be given), and "-c" specifies channels. The 4way topology file should be specified.